### PR TITLE
firewall-checker: report connection timeouts

### DIFF
--- a/networking/images/firewall-checker/tcp.go
+++ b/networking/images/firewall-checker/tcp.go
@@ -12,6 +12,15 @@ import (
 const tcpConnectTimeout = time.Millisecond * 500
 const tcpReadTimeout = time.Millisecond * 500
 
+func isTimeoutOrRefused(proto string, addr string, err error) bool {
+	var nerr net.Error
+	if errors.As(err, &nerr) && nerr.Timeout() {
+		fmt.Printf("%s to %s timed out\n", proto, addr)
+		return true
+	}
+	return errors.Is(err, syscall.ECONNREFUSED)
+}
+
 func checkTcp(addr string) (bool, error) {
 	return checkTcpWithContent(addr, "Hello tcp server")
 }
@@ -27,7 +36,7 @@ func checkTcpWithContent(addr string, body string) (bool, error) {
 func sendTcp(addr string, body string) (string, error) {
 	conn, err := net.DialTimeout("tcp", addr, tcpConnectTimeout)
 	if err != nil {
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() || errors.Is(err, syscall.ECONNREFUSED) {
+		if isTimeoutOrRefused("TCP", addr, err) {
 			return "", nil
 		}
 		fmt.Printf("ERROR: failed to create tcp connection: %v\n", err.Error())
@@ -37,7 +46,7 @@ func sendTcp(addr string, body string) (string, error) {
 	defer conn.Close()
 	_, err = conn.Write([]byte(body))
 	if err != nil {
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() || errors.Is(err, syscall.ECONNREFUSED) {
+		if isTimeoutOrRefused("TCP", addr, err) {
 			return "", nil
 		}
 		fmt.Printf("ERROR: failed send data using udp: %v\n", err.Error())
@@ -48,7 +57,7 @@ func sendTcp(addr string, body string) (string, error) {
 	conn.SetReadDeadline(time.Now().Add(tcpReadTimeout))
 	receivedLen, err := conn.Read(received)
 	if err != nil {
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() || errors.Is(err, syscall.ECONNREFUSED) {
+		if isTimeoutOrRefused("TCP", addr, err) {
 			return "", nil
 		}
 		fmt.Printf("ERROR: failed to receive data using udp: %v\n", err.Error())

--- a/networking/images/firewall-checker/udp.go
+++ b/networking/images/firewall-checker/udp.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -43,7 +41,7 @@ func sendUdp(addr string) (string, error) {
 	conn.SetReadDeadline(time.Now().Add(udpReadTimeout))
 	receivedLen, err := conn.Read(received)
 	if err != nil {
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() || errors.Is(err, syscall.ECONNREFUSED) {
+		if isTimeoutOrRefused("UDP", addr, err) {
 			return "", nil
 		}
 		fmt.Printf("ERROR: failed to receive data using udp: %v\n", err.Error())


### PR DESCRIPTION
TCP/UDP checks turned both a timeout and a refused connection into a silent `NO`, so high latency to the lab was indistinguishable from a firewall rule. A timeout now prints `<proto> to <addr> timed out`; refused still maps to `NO`. 
